### PR TITLE
python 3 maxint to maxsize

### DIFF
--- a/ged4py/algorithm/abstract_graph_edit_dist.py
+++ b/ged4py/algorithm/abstract_graph_edit_dist.py
@@ -78,7 +78,7 @@ class AbstractGraphEditDistance(object):
         print("cost matrix:")
         for column in self.create_cost_matrix():
             for row in column:
-                if row == sys.maxint:
+                if row == sys.maxsize:
                     print ("inf\t")
                 else:
                     print ("%.2f\t" % float(row))

--- a/test.py
+++ b/test.py
@@ -8,4 +8,4 @@ g.add_node("C",weight=1)
 g2=g.copy()
 g.add_edge("A","C")
 from ged4py.algorithm import graph_edit_dist
-print(graph_edit_dist.compare(g,g2))
+print(graph_edit_dist.compare(g,g2, True))


### PR DESCRIPTION
Matrix printing was failing on python 3.6 as maxint is no longer part of the sys module. 