### PR TITLE
Installing ged4py via pip results in the subpackages not being found

### DIFF
--- a/ged4py/algorithm/abstract_graph_edit_dist.py
+++ b/ged4py/algorithm/abstract_graph_edit_dist.py
@@ -78,7 +78,7 @@ class AbstractGraphEditDistance(object):
         print("cost matrix:")
         for column in self.create_cost_matrix():
             for row in column:
-                if row == sys.maxint:
+                if row == sys.maxsize:
                     print ("inf\t")
                 else:
                     print ("%.2f\t" % float(row))

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,9 @@
-from distutils.core import setup
+from setuptools import setup, find_packages
 
 setup(
     name='ged4py',
-    version='0.1dev',
-    packages=['ged4py',],
+    vAersion='0.1dev-a',
+    packages=find_packages(),
     author='Jacques Fize',
     license='MIT',
     long_description=open('README.md').read(),

--- a/test.py
+++ b/test.py
@@ -8,4 +8,4 @@ g.add_node("C",weight=1)
 g2=g.copy()
 g.add_edge("A","C")
 from ged4py.algorithm import graph_edit_dist
-print(graph_edit_dist.compare(g,g2))
+print(graph_edit_dist.compare(g,g2, True))


### PR DESCRIPTION
fixed by adding `find_packages` and using `setuptools` instead of `distutils.core`